### PR TITLE
Theoretical race fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,6 +325,12 @@ function makeManager (opts) {
       outgoingConnectionsEstablished.push(item);
 
     }).listen(address);
+
+    server.on('listening', () => {
+      debug("Server listening for outgoing connections. Starting control unix socket.");
+      makeControlSocket();
+    });
+
   }
 
   // For some reason, .server gets called twice...
@@ -688,7 +694,6 @@ function makeManager (opts) {
 
 
   listenForOutgoingEstablished();
-  makeControlSocket();
   makeFullyEstablishConnectionsHandler();
 
   return {

--- a/index.js
+++ b/index.js
@@ -324,13 +324,14 @@ function makeManager (opts) {
 
       outgoingConnectionsEstablished.push(item);
 
-    }).listen(address);
+    });
 
     server.on('listening', () => {
       debug("Server listening for outgoing connections. Starting control unix socket.");
       makeControlSocket();
     });
 
+    return server.listen(address);
   }
 
   // For some reason, .server gets called twice...


### PR DESCRIPTION
Should only start control socket once outgoing connections socket has started